### PR TITLE
Version bump for 0.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "immutable": "^3.8.1",
     "lodash.has": "^4.5.2",
     "lodash.isequal": "^4.4.0",
-    "mapbox-gl": "^0.28.0",
-    "mapbox-gl-style-spec": "^8.8.1",
+    "mapbox-gl": "^0.31.0",
+    "mapbox-gl-style-spec": "^8.11.0",
     "react": "^15.0.0"
   },
   "devDependencies": {

--- a/src/utils/transform.jsx
+++ b/src/utils/transform.jsx
@@ -18,6 +18,8 @@ export const cloneTransform = (transform) => {
   clonedTransform._altitude = transform.altitude;
   clonedTransform._pitch = transform.pitch;
   clonedTransform._unmodified = transform._unmodified;
+  clonedTransform._renderWorldCopies = transform._renderWorldCopies;
+  clonedTransform._fov = transform._fov;
   // Last modifier calls calculatePosMatrix
   clonedTransform.zoom = transform.zoom;
   return clonedTransform;

--- a/test/setup.js
+++ b/test/setup.js
@@ -41,6 +41,10 @@ const removeTypes = require('flow-remove-types');
 
 const _compileSuper = Module.prototype._compile;
 Module.prototype._compile = function _compile(source, filename) {
-  const transformedSource = filename.indexOf('node_modules/mapbox-gl') !== -1 ? removeTypes(source) : source;
-  _compileSuper.call(this, transformedSource, filename);
+  const transformedSource = filename.indexOf('node_modules/mapbox-gl/') !== -1 ? removeTypes(source) : source;
+  if (!transformedSource.replace && transformedSource.toString) {
+    _compileSuper.call(this, transformedSource.toString(), filename);
+  } else {
+    _compileSuper.call(this, transformedSource, filename);
+  }
 };


### PR DESCRIPTION
This is a version bump to support 0.31.0.

* Adds in support for changes in remove flow types
* Version bumped 0.31.0 of mapbox-gl-js
* Added in new fov, worldRenderCopies into transform duplicate
* Tests confirmed passing for 0.31.0 in node as well as browser