### PR TITLE
Updates the lifecycle to match the required 16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "element-resize-event": "^2.0.9",
     "lodash.has": "^4.5.2",
     "lodash.isequal": "^4.5.0",
-    "prop-types": "^15.6.2",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.6.1",
+    "react-dom": "^16.6.1",
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
     "mapbox-gl": "^0.51.0"

--- a/src/map-events.jsx
+++ b/src/map-events.jsx
@@ -7,8 +7,8 @@ class MapEvents extends React.Component {
     this._updateListeners({}, this.props);
   }
 
-  componentDidUpdate(nextProps) {
-    this._updateListeners(this.props, nextProps);
+  componentDidUpdate(prevProps) {
+    this._updateListeners(prevProps, this.props);
   }
 
   componentWillUnmount() {

--- a/src/map.jsx
+++ b/src/map.jsx
@@ -118,12 +118,12 @@ class Map extends React.Component {
     addResizeListener(this.container, this._resizedContainer);
   }
 
-  componentWillReceiveProps(nextProps) {
-    this._updateConvenienceHandlers(this.props, nextProps);
-    this._updateStyle(this.props.mapStyle, nextProps.mapStyle);
-    this._updateMapOptions(this.props, nextProps);
-    this._updateMapViewport(this.props, nextProps);
-    this._updateFeatureState(this.props, nextProps);
+  componentDidUpdate(prevProps) {
+    this._updateConvenienceHandlers(prevProps, this.props);
+    this._updateStyle(prevProps.mapStyle, this.props.mapStyle);
+    this._updateMapOptions(prevProps, this.props);
+    this._updateMapViewport(prevProps, this.props);
+    this._updateFeatureState(prevProps, this.props);
   }
 
   componentWillUnmount() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3766,7 +3766,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.2.0:
+react-dom@^16.6.1:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.1.tgz#5476e08694ae504ae385a28b62ecc4fe3a29add9"
   dependencies:
@@ -3775,7 +3775,7 @@ react-dom@^16.2.0:
     prop-types "^15.6.2"
     scheduler "^0.11.0"
 
-react@^16.2.0:
+react@^16.6.1:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.1.tgz#ee2aef4f0a09e494594882029821049772f915fe"
   dependencies:


### PR DESCRIPTION
Retires lifecycle methods that are no longer safe in 16.6